### PR TITLE
ENH: get MySQL port from the configuration file

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -3,6 +3,7 @@ package config
 // MySQLConfig client configuration
 type MySQLConfig struct {
 	DNS      string `yaml:"dns"`
+	Port     int    `yaml:"port"`
 	Username string `yaml:"username"`
 	Password string `yaml:"password"`
 	Schema   string `yaml:"schema"`

--- a/state/mysql.go
+++ b/state/mysql.go
@@ -49,7 +49,7 @@ func (u *TableDeploymentsHash) TableName() string {
 func NewMysqlClient(config *config.MySQLConfig) *MySQLManager {
 
 	var err error
-	db, err := gorm.Open("mysql", fmt.Sprintf("%s:%s@tcp(%s)/%s?charset=utf8&parseTime=True&loc=Local", config.Username, config.Password, config.DNS, config.Schema))
+	db, err := gorm.Open("mysql", fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?charset=utf8&parseTime=True&loc=Local", config.Username, config.Password, config.DNS, config.Port, config.Schema))
 	if strings.ToLower(fmt.Sprintf("%s", log.GetLevel())) == "debug" {
 		db.LogMode(true)
 	}


### PR DESCRIPTION
I have added the option to change the MySQL port connection from configuration file (Kubernetes watcher and API