### PR TITLE
Fix api applies response

### DIFF
--- a/api/kubernetes/storage.go
+++ b/api/kubernetes/storage.go
@@ -102,7 +102,7 @@ func (my *MySQLStorage) builderApplications(queryFillter FilterApplications) *go
 	}
 
 	if queryFillter.Distinct {
-		queryBuilder = my.client.DB.Where("time IN (?)", my.client.DB.Select("MAX(time)").Model(&state.TableKubernetes{}).Group("name").QueryExpr())
+		queryBuilder = queryBuilder.Where("time IN (?)", my.client.DB.Select("MAX(time)").Model(&state.TableKubernetes{}).Group("name").QueryExpr())
 	}
 
 	// We only support a case where we have both filter of From and To


### PR DESCRIPTION
When sending a request to API service for getting the last deployment with distinct=true, the limit and offset was not set to gorm model

**Request:**
```
curl 127.0.0.1:8080/api/v1/kubernetes/applications\?offset\=0\&limit\=2\&sortBy\=Name\&sortDirection\=desc\&from\=\&to\=\&distinct\=true
```
**MySQL query:**

```
SELECT * FROM `kubernetes`  WHERE (time IN (SELECT MAX(time) FROM `kubernetes`   GROUP BY name)) ORDER BY time desc LIMIT 1 OFFSET 0
```