### PR TITLE
Change prefix annotation & alignment progress-deadline-seconds logic

### DIFF
--- a/examples/apply/README.md
+++ b/examples/apply/README.md
@@ -27,7 +27,6 @@ Parameter | Description | Default
 `daemonset.annotations` The annotations used in ingress | `list of annotations`
 `deployment.count` | Number of Deplotments deployments | `1`
 `deployment.replicas` | Number of Deplotments replicas | `3`
-`deployment.progressDeadlineSeconds` | Maximum deployment time | `300`
 `deployment.name` | Prefix of Daemonset | `statusbay-deployment`
 `deployment.image.repository` | container image repository | `nginx`
 `deployment.image.tag` | container image tag | `latest`

--- a/examples/apply/templates/deployment.yaml
+++ b/examples/apply/templates/deployment.yaml
@@ -12,7 +12,6 @@ metadata:
 {{ toYaml $root.Values.deployment.annotations | indent 4}}
 spec:
   replicas: {{ $root.Values.deployment.replicas}}
-  progressDeadlineSeconds: {{ $root.Values.deployment.progressDeadlineSeconds}}
   selector:
     matchLabels:
       component: {{ $name }}

--- a/examples/apply/values.yaml
+++ b/examples/apply/values.yaml
@@ -57,6 +57,7 @@ deployment:
       port: 80
     
   annotations:
+    statusbay.io/progress-deadline-seconds: "5"
     statusbay.io/application-name: "statusbay-application"
     statusbay.io/report-slack-channels: "#foo-channel"
     statusbay.io/report-deploy-by: foo@similarweb.com

--- a/watcher/kubernetes/metadata.go
+++ b/watcher/kubernetes/metadata.go
@@ -2,14 +2,18 @@ package kuberneteswatcher
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
 )
 
 const (
-	// METAPREFIX is statusbay prefix annotations
-	METAPREFIX = "statusbay.io"
+	//ANNOTATION_PREFIX is statusbay prefix annotations
+	ANNOTATION_PREFIX = "statusbay.io"
+
+	//ANNOTATION_PROGRESS_DEADLINE_SECONDS is statusbay progress deadline seconds
+	ANNOTATION_PROGRESS_DEADLINE_SECONDS = "progress-deadline-seconds"
 )
 
 // GetMetadataByPrefix will return anitasion values key prefix
@@ -52,7 +56,7 @@ func GetMetadata(annotations map[string]string, search string) string {
 func GetMetricsDataFromAnnotations(annotations map[string]string) []Metrics {
 
 	metrics := []Metrics{}
-	prefix := fmt.Sprintf("%s/metrics-", METAPREFIX)
+	prefix := fmt.Sprintf("%s/metrics-", ANNOTATION_PREFIX)
 
 	for key, val := range annotations {
 		if strings.HasPrefix(key, prefix) {
@@ -82,7 +86,7 @@ func GetMetricsDataFromAnnotations(annotations map[string]string) []Metrics {
 func GetAlertsDataFromAnnotations(annotations map[string]string) []Alerts {
 
 	alerts := []Alerts{}
-	prefix := fmt.Sprintf("%s/alerts-", METAPREFIX)
+	prefix := fmt.Sprintf("%s/alerts-", ANNOTATION_PREFIX)
 
 	for key, val := range annotations {
 		if strings.HasPrefix(key, prefix) {
@@ -98,4 +102,16 @@ func GetAlertsDataFromAnnotations(annotations map[string]string) []Alerts {
 
 	return alerts
 
+}
+
+//GetProgressDeadlineApply returns the maximum apply progress. if the field not exists in annotation list default value will returned
+func GetProgressDeadlineApply(annotations map[string]string, defaultValue int64) int64 {
+
+	progressDeadLineAnnotations := GetMetadata(annotations, fmt.Sprintf("%s/%s", ANNOTATION_PREFIX, ANNOTATION_PROGRESS_DEADLINE_SECONDS))
+	progressDeadLine, err := strconv.ParseInt(progressDeadLineAnnotations, 10, 64)
+	if err != nil {
+		progressDeadLine = int64(defaultValue)
+	}
+
+	return progressDeadLine
 }

--- a/watcher/kubernetes/metadata_test.go
+++ b/watcher/kubernetes/metadata_test.go
@@ -71,7 +71,7 @@ func TestGetMetadata(t *testing.T) {
 func TestGetMetricsDataFromAnnotations(t *testing.T) {
 
 	annotations := map[string]string{
-		fmt.Sprintf("%s/metrics-providername-metric-name", METAPREFIX): "metric query 1",
+		fmt.Sprintf("%s/metrics-providername-metric-name", ANNOTATION_PREFIX): "metric query 1",
 	}
 
 	metrics := GetMetricsDataFromAnnotations(annotations)
@@ -94,7 +94,7 @@ func TestGetMetricsDataFromAnnotations(t *testing.T) {
 
 func TestGetAlertsDataFromAnnotations(t *testing.T) {
 	annotations := map[string]string{
-		fmt.Sprintf("%s/alerts-providername", METAPREFIX): "foo,foo1",
+		fmt.Sprintf("%s/alerts-providername", ANNOTATION_PREFIX): "foo,foo1",
 	}
 
 	alerts := GetAlertsDataFromAnnotations(annotations)
@@ -111,4 +111,31 @@ func TestGetAlertsDataFromAnnotations(t *testing.T) {
 	if alert.Tags != "foo,foo1" {
 		t.Fatalf("unexpected alert tags, got %s expected %s", alert.Tags, "foo,foo1")
 	}
+}
+
+func TestGetProgressDeadlineApply(t *testing.T) {
+
+	t.Run("get_progress_deadline_annotation", func(t *testing.T) {
+
+		annotations := map[string]string{
+			fmt.Sprintf("%s/%s", ANNOTATION_PREFIX, ANNOTATION_PROGRESS_DEADLINE_SECONDS): "10",
+		}
+		progressDeadlineSeconds := GetProgressDeadlineApply(annotations, 2)
+
+		if progressDeadlineSeconds != 10 {
+			t.Fatalf("unexpected %s annotation value, got %d expected %d", ANNOTATION_PROGRESS_DEADLINE_SECONDS, progressDeadlineSeconds, 10)
+
+		}
+	})
+	t.Run("get_un_exists_progress_deadline_annotation", func(t *testing.T) {
+
+		annotations := map[string]string{}
+		progressDeadlineSeconds := GetProgressDeadlineApply(annotations, 60)
+
+		if progressDeadlineSeconds != 60 {
+			t.Fatalf("unexpected %s annotation value, got %d expected %d", ANNOTATION_PROGRESS_DEADLINE_SECONDS, progressDeadlineSeconds, 60)
+
+		}
+	})
+
 }

--- a/watcher/kubernetes/registry.go
+++ b/watcher/kubernetes/registry.go
@@ -149,8 +149,8 @@ func (dr *RegistryManager) NewApplication(
 	defer dr.newAppLock.Unlock()
 
 	encodedID := generateID(appName, namespace)
-	reportTo := GetMetadataByPrefix(annotations, fmt.Sprintf("%s/%s", METAPREFIX, "report-"))
-	deployBy := GetMetadata(annotations, fmt.Sprintf("%s/%s", METAPREFIX, "report-deploy-by"))
+	reportTo := GetMetadataByPrefix(annotations, fmt.Sprintf("%s/%s", ANNOTATION_PREFIX, "report-"))
+	deployBy := GetMetadata(annotations, fmt.Sprintf("%s/%s", ANNOTATION_PREFIX, "report-deploy-by"))
 	deployTime := time.Now().Unix()
 	ctx, cancelFn := context.WithCancel(context.Background())
 

--- a/watcher/kubernetes/statefulset.go
+++ b/watcher/kubernetes/statefulset.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"statusbay/serverutil"
 	"statusbay/watcher/kubernetes/common"
-	"strconv"
 	"time"
 
 	"github.com/mitchellh/hashstructure"
@@ -115,12 +114,7 @@ func (ssm *StatefulsetManager) watchStatefulsets(ctx context.Context) {
 				if applicationName != "" {
 					statefulsetName = applicationName
 				}
-				// extract annotation for progressDeadLine since statefulset don't have this feature
-				progressDeadLineAnnotations := GetMetadata(statefulset.GetAnnotations(), "statusbay.io/progress-deadline-seconds")
-				progressDeadLine, err := strconv.ParseInt(progressDeadLineAnnotations, 10, 64)
-				if err != nil {
-					progressDeadLine = int64(ssm.maxDeploymentTime)
-				}
+
 				if event.Type == eventwatch.Modified || event.Type == eventwatch.Added || event.Type == eventwatch.Deleted {
 					// handle modified event
 					if event.Type == eventwatch.Deleted {
@@ -132,6 +126,10 @@ func (ssm *StatefulsetManager) watchStatefulsets(ctx context.Context) {
 						}
 					}
 					appRegistry := ssm.registryManager.Get(statefulsetName, statefulset.GetNamespace())
+
+					// extract annotation for progressDeadLine since statefulset don't have this feature
+					progressDeadLine := GetProgressDeadlineApply(statefulset.GetAnnotations(), ssm.maxDeploymentTime)
+
 					if appRegistry == nil {
 						statefulsetStatus := common.DeploymentStatusRunning
 						if event.Type == eventwatch.Deleted {
@@ -154,18 +152,14 @@ func (ssm *StatefulsetManager) watchStatefulsets(ctx context.Context) {
 						progressDeadLine)
 					statefulsetWatchListOptions := metaV1.ListOptions{
 						LabelSelector: labels.SelectorFromSet(statefulset.GetLabels()).String()}
-					maxWatchTime := ssm.maxDeploymentTime
 
-					if progressDeadLine > ssm.maxDeploymentTime {
-						maxWatchTime = progressDeadLine
-					}
 					go ssm.watchStatefulset(
 						appRegistry.ctx,
 						appRegistry.cancelFn,
 						registryApply,
 						statefulsetWatchListOptions,
 						statefulset.GetNamespace(),
-						maxWatchTime)
+						progressDeadLine)
 				} else {
 					log.WithFields(log.Fields{
 						"event_type":  event.Type,


### PR DESCRIPTION
Hey, 
I have alignment the progress deadline logic in all watcher components (statefulset, daemonset, and deployment)

 