### PR TITLE
Add unique key in TableStateless.js

### DIFF
--- a/ui/client/src/components/Table/TableStateless.js
+++ b/ui/client/src/components/Table/TableStateless.js
@@ -12,7 +12,7 @@ import makeStyles from '@material-ui/core/styles/makeStyles';
 const renderRows = (config, data, page) => data.map((row, rowIndex) => {
   const RowComponent = config.row.render(row, rowIndex);
   // eslint-disable-next-line max-len
-  const rowCells = config.cells.map((cellConfig) => <TableCell>{cellConfig.cell(row, ((page) * data.length) + rowIndex)}</TableCell>);
+  const rowCells = config.cells.map((cellConfig) => <TableCell key={`cell-${row.name}`}>{cellConfig.cell(row, ((page) * data.length) + rowIndex)}</TableCell>);
   return (
     <RowComponent>
       {rowCells}
@@ -21,7 +21,7 @@ const renderRows = (config, data, page) => data.map((row, rowIndex) => {
 });
 
 const renderLoadingState = (config) => [...Array(10).keys()].map((index) => (
-  <TableRow>
+  <TableRow key={`row-${index}`}>
     {
         config.cells.map((cell, cellIndex, cells) => {
           const isLast = cellIndex === cells.length - 1;


### PR DESCRIPTION
Fix that consol warning:


```
Warning: Each child in a list should have a unique "key" prop.

Check the render method of `TableStateless`. See https://fb.me/react-warning-keys for more information.
    in WithStyles(ForwardRef(TableRow)) (at TableStateless.js:24)
    in TableStateless
    in TableStateless (at Table.js:303)
    in div (created by ForwardRef(Paper))
    in ForwardRef(Paper) (created by WithStyles(ForwardRef(Paper)))
    in WithStyles(ForwardRef(Paper)) (created by ForwardRef(TableContainer))
    in ForwardRef(TableContainer) (created by WithStyles(ForwardRef(TableContainer)))
    in WithStyles(ForwardRef(TableContainer)) (at Table.js:244)
    in div (created by ForwardRef(Paper))
    in ForwardRef(Paper) (created by WithStyles(ForwardRef(Paper)))
    in WithStyles(ForwardRef(Paper)) (at Table.js:243)
    in div (at Table.js:235)
    in Table (at Applications.js:18)
    in Applications (at App.js:102)
    in Route (at App.js:101)
    in Switch (at App.js:100)
    in div (created by ForwardRef(Grid))
    in ForwardRef(Grid) (created by WithStyles(ForwardRef(Grid)))
    in WithStyles(ForwardRef(Grid)) (at App.js:97)
    in div (created by ForwardRef(Grid))
    in ForwardRef(Grid) (created by WithStyles(ForwardRef(Grid)))
    in WithStyles(ForwardRef(Grid)) (at App.js:96)
    in main (at App.js:94)
```