### PR TITLE
Validate Kubernetes Watcher has http:// prefix in slack base url

### DIFF
--- a/notifiers/slack/slack.go
+++ b/notifiers/slack/slack.go
@@ -87,7 +87,7 @@ func (sl *Manager) sendToAll(stage ReportStage, message watcherCommon.Deployment
 	status := strings.ToUpper(string(message.Status))
 
 	var slackBaseURL string = sl.urlBase
-	if !strings.HasPrefix(slackBaseURL, "http://") {
+	if !strings.HasPrefix(slackBaseURL, "http") {
 		message.LogEntry.WithField("slack_base_url", slackBaseURL).Debug("slack base url has a missing *http://* going to add it")
 		slackBaseURL = fmt.Sprintf("http://%s", sl.urlBase)
 	}


### PR DESCRIPTION
Hi @kaplanelad ,
I have added a check to see if the slack base url contains "http://" as a prefix if not it will add it.