### PR TITLE
Build minor changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@
 # Build golang container
 ##########################################
 FROM golang:1.22.4-alpine AS go-builder
+ARG GOFLAGS=""
+ENV GOFLAGS="$GOFLAGS"
 
 # Install OS level dependencies
 RUN apk add --update alpine-sdk git && \

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.19.1
 	github.com/prometheus/common v0.54.0
+	github.com/sethvargo/go-envconfig v1.0.3
 	github.com/similarweb/client-notifier v0.1.4
 	github.com/sirupsen/logrus v1.9.3
 	github.com/zorkian/go-datadog-api v2.30.0+incompatible
@@ -59,7 +60,6 @@ require (
 	github.com/onsi/ginkgo v1.16.4 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
-	github.com/sethvargo/go-envconfig v1.0.3 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	golang.org/x/net v0.26.0 // indirect


### PR DESCRIPTION
Newer versions of golang automatically try to include VCS information into the binary, this is their default behaviour.

Some build environments do not directly include .git repository into the VCS root and this might break the build process because golang tries to pull that information and fails, with the whole build process.

This change will allow the build environment to pass any flags it needs to the go binary in GOFLAGS argument.

To fix the above-mentioned issue, the environment will need to pass:
`GOFLAGS='-buildvcs=false'`
As build argument to docker.