### PR TITLE
Fix datadog api library

### DIFF
--- a/api/metrics/datadog/datadog_test.go
+++ b/api/metrics/datadog/datadog_test.go
@@ -2,7 +2,7 @@ package datadog
 
 import (
 	"context"
-	testutil "statusbay/api/metrics/datadog/testutils"
+	testutils "statusbay/api/metrics/datadog/testutils"
 	"statusbay/cache"
 	"sync"
 	"testing"
@@ -10,12 +10,13 @@ import (
 )
 
 func MockDatadog(cacheExpiration, cacheCleanupInterval time.Duration) *Datadog {
-	ddMockClient := testutil.NewMockDatadog()
+	metricsApi := testutils.NewMockMockMetricsApi()
 	cache := &cache.CacheManager{
 		Client: &cache.NoOpCache{},
 	}
 
-	dd := NewDatadogManager(cache, cacheExpiration, "", "", ddMockClient)
+	dd := NewDatadogManager(cache, cacheExpiration, "", "")
+	dd.metricsApi = metricsApi
 
 	return dd
 }

--- a/api/metrics/datadog/testutils/client.go
+++ b/api/metrics/datadog/testutils/client.go
@@ -1,39 +1,70 @@
 package testutil
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	_nethttp "net/http"
+	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 
-	"github.com/zorkian/go-datadog-api"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
 )
 
-func MockQueryMetrics(from int64, to int64, query string) ([]datadog.Series, error) {
+type MockMetricsApi struct {
+}
 
+func NewMockMockMetricsApi() *MockMetricsApi {
+	return &MockMetricsApi{}
+}
+
+func (m *MockMetricsApi) QueryMetrics(ctx context.Context, from int64, to int64, query string) (datadogV1.MetricsQueryResponse, *_nethttp.Response, error) {
+	var (
+		resp     datadogV1.MetricsQueryResponse
+		httpResp *_nethttp.Response
+	)
 	_, filename, _, _ := runtime.Caller(0)
-	currentFolderPath := filepath.Dir(filename)
-	reader, err := ioutil.ReadFile(fmt.Sprintf("%s/mock/%s.json", currentFolderPath, query))
 
+	// Read directory contents
+	mockQueryDir := filepath.Join(filepath.Dir(filename), "mock")
+	files, err := os.ReadDir(mockQueryDir)
 	if err != nil {
-		return nil, err
+		return resp, httpResp, err
 	}
-	var data []datadog.Series
-	err = json.Unmarshal(reader, &data)
+
+	// Create a list of accessible queries
+	mockQueryList := make(map[string]string, len(files))
+	for _, file := range files {
+		if !file.IsDir() {
+			mockQueryName := strings.TrimSuffix(file.Name(), filepath.Ext(file.Name()))
+			mockQueryFilePath := filepath.Join(mockQueryDir, file.Name())
+			mockQueryList[mockQueryName] = mockQueryFilePath
+		}
+	}
+
+	// Check if the query parameter is among the accessible queries
+	mockQueryFilePath, found := mockQueryList[query]
+	if !found {
+		return resp, httpResp, fmt.Errorf("Mock file not found for query: %s", query)
+	}
+
+	reader, err := os.ReadFile(mockQueryFilePath)
 	if err != nil {
-		return nil, err
+		return resp, httpResp, err
 	}
-	return data, nil
-}
 
-type MockDatadog struct {
-}
+	err = json.Unmarshal(reader, &resp)
+	if err != nil {
+		fmt.Printf("Error reading mock response:\n %s\n", err)
+		return resp, httpResp, err
+	}
 
-func NewMockDatadog() *MockDatadog {
-	return &MockDatadog{}
-}
-
-func (m *MockDatadog) QueryMetrics(from int64, to int64, query string) ([]datadog.Series, error) {
-	return MockQueryMetrics(from, to, query)
+	err = json.Unmarshal(reader, &resp)
+	if err != nil {
+		fmt.Printf("Error reading mock response:\n %s\n", err)
+		return resp, httpResp, err
+	}
+	return resp, httpResp, nil
 }

--- a/api/metrics/datadog/testutils/mock/multiple-metric.json
+++ b/api/metrics/datadog/testutils/mock/multiple-metric.json
@@ -1,38 +1,40 @@
-[
-  {
-    "metric": "foo.metric.response.4xx",
-    "display_name": "foo.metric.response.4xx",
-    "pointlist": [
-      [
-        1557941880000,
-        1
+{
+  "series": [
+    {
+      "metric": "foo.metric.response.4xx",
+      "display_name": "foo.metric.response.4xx",
+      "pointlist": [
+        [
+          1557941880000,
+          1
+        ],
+        [
+          1557941910000,
+          2
+        ],
+        [
+          1557942010000,
+          2
+        ]
       ],
-      [
-        1557941910000,
-        2
+      "scope": "service:foo-production",
+      "expression": "sum:sw.foo.metric.response.4xx{service:foo-production}"
+    },
+    {
+      "metric": "foo.metric.response.5xx",
+      "display_name": "foo.metric.response.5xx",
+      "pointlist": [
+        [
+          1557941880000,
+          1
+        ],
+        [
+          1557941910000,
+          2
+        ]
       ],
-      [
-        1557942010000,
-        2
-      ]
-    ],
-    "scope": "service:foo-production",
-    "expression": "sum:sw.foo.metric.response.4xx{service:foo-production}"
-  },
-  {
-    "metric": "foo.metric.response.5xx",
-    "display_name": "foo.metric.response.5xx",
-    "pointlist": [
-      [
-        1557941880000,
-        1
-      ],
-      [
-        1557941910000,
-        2
-      ]
-    ],
-    "scope": "service:foo-production",
-    "expression": "sum:sw.foo.metric.response.5xx{service:foo-production}"
-  }
-]
+      "scope": "service:foo-production",
+      "expression": "sum:sw.foo.metric.response.5xx{service:foo-production}"
+    }
+  ]
+}

--- a/api/metrics/datadog/testutils/mock/single-metric.json
+++ b/api/metrics/datadog/testutils/mock/single-metric.json
@@ -1,18 +1,20 @@
-[
-  {
-    "metric": "foo.metric.response.2xx",
-    "display_name": "foo.metric.response.2xx",
-    "pointlist": [
-      [
-        1557941880000,
-        1
+{
+  "series": [
+    {
+      "metric": "foo.metric.response.2xx",
+      "display_name": "foo.metric.response.2xx",
+      "pointlist": [
+        [
+          1557941880000,
+          1
+        ],
+        [
+          1557941910000,
+          2
+        ]
       ],
-      [
-        1557941910000,
-        2
-      ]
-    ],
-    "scope": "service:foo-production",
-    "expression": "sum:sw.foo.metric.response.2xx{service:foo-production}"
-  }
-]
+      "scope": "service:foo-production",
+      "expression": "sum:sw.foo.metric.response.2xx{service:foo-production}"
+    }
+  ]
+}

--- a/api/metrics/structs.go
+++ b/api/metrics/structs.go
@@ -26,7 +26,7 @@ func Load(metricsProviders *config.MetricsProvider, cache *cache.CacheManager) m
 		return providers
 	}
 	if metricsProviders.DataDog != nil {
-		providers["datadog"] = datadog.NewDatadogManager(cache, metricsProviders.DataDog.CacheExpiration, metricsProviders.DataDog.APIKey, metricsProviders.DataDog.AppKey, nil)
+		providers["datadog"] = datadog.NewDatadogManager(cache, metricsProviders.DataDog.CacheExpiration, metricsProviders.DataDog.APIKey, metricsProviders.DataDog.AppKey)
 	}
 
 	if metricsProviders.Prometheus != nil {

--- a/config/api.go
+++ b/config/api.go
@@ -11,39 +11,39 @@ import (
 
 // MetricsProvider struct
 type MetricsProvider struct {
-	DataDog    *DatadogConfig    `yaml:"datadog"`
-	Prometheus *PrometheusConfig `yaml:"prometheus"`
+	DataDog    *DatadogConfig    `yaml:"datadog" env:", prefix=DATADOG_"`
+	Prometheus *PrometheusConfig `yaml:"prometheus" env:", prefix=PROMETHEUS_"`
 }
 
 // AlertProvider struct
 type AlertProvider struct {
-	Statuscake *Statuscake `yaml:"statuscake"`
-	Pingdom    *Pingdom    `yaml:"pingdom"`
+	Statuscake *Statuscake `yaml:"statuscake" env:", prefix=STATUSCAKE_"`
+	Pingdom    *Pingdom    `yaml:"pingdom"  env:", prefix=PINGDOM_"`
 }
 
 // DatadogConfig configuration
 type DatadogConfig struct {
-	APIKey          string        `yaml:"api_key"`
-	AppKey          string        `yaml:"app_key"`
+	APIKey          string        `yaml:"api_key" env:"API_KEY, overwrite"`
+	AppKey          string        `yaml:"app_key" env:"APP_KEY, overwrite"`
 	CacheExpiration time.Duration `yaml:"cache_expiration"`
 }
 
 // PrometheusConfig configuration
 type PrometheusConfig struct {
-	Address string `yaml:"address"`
+	Address string `yaml:"address" env:"ADDRESS, overwrite"`
 }
 
 // Pingdom configuration
 type Pingdom struct {
-	Endpoint string `yaml:"endpoint"`
-	Token    string `yaml:"token"`
+	Endpoint string `yaml:"endpoint" env:"ENDPOINT, overwrite"`
+	Token    string `yaml:"token" env:"TOKEN, overwrite"`
 }
 
 // Statuscake configuration
 type Statuscake struct {
-	Endpoint string `yaml:"endpoint"`
-	Username string `yaml:"username"`
-	APIKey   string `yaml:"api_key"`
+	Endpoint string `yaml:"endpoint" env:"ENDPOINT, overwrite"`
+	Username string `yaml:"username" env:"USERNAME, overwrite"`
+	APIKey   string `yaml:"api_key" env:"API_KEY, overwrite"`
 }
 
 // KubernetesMarksEvents is the struct representing the events StatusBay marks
@@ -62,8 +62,8 @@ type API struct {
 	Log             LogConfig          `yaml:"log"`
 	MySQL           *state.MySQLConfig `yaml:"mysql" env:", prefix=MYSQL_"`
 	Redis           *cache.RedisConfig `yaml:"redis"`
-	MetricsProvider *MetricsProvider   `yaml:"metrics"`
-	AlertProvider   *AlertProvider     `yaml:"alerts"`
+	MetricsProvider *MetricsProvider   `yaml:"metrics"  env:", prefix=METRICS_"`
+	AlertProvider   *AlertProvider     `yaml:"alerts"  env:", prefix=ALERTS_"`
 	Telemetry       MetricsConfig      `yaml:"telemetry"`
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module statusbay
 
 require (
+	github.com/DataDog/datadog-api-client-go/v2 v2.26.0
 	github.com/armon/go-metrics v0.4.1
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/go-redis/redis/v7 v7.4.1
@@ -16,7 +17,6 @@ require (
 	github.com/sethvargo/go-envconfig v1.0.3
 	github.com/similarweb/client-notifier v0.1.4
 	github.com/sirupsen/logrus v1.9.3
-	github.com/zorkian/go-datadog-api v2.30.0+incompatible
 	gopkg.in/gemnasium/logrus-graylog-hook.v2 v2.0.7
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.30.1
@@ -27,9 +27,9 @@ require (
 require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/DataDog/datadog-go v4.8.3+incompatible // indirect
+	github.com/DataDog/zstd v1.5.2 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.12.1 // indirect
@@ -40,6 +40,7 @@ require (
 	github.com/go-openapi/jsonreference v0.21.0 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/go-sql-driver/mysql v1.8.1 // indirect
+	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,12 @@
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
+github.com/DataDog/datadog-api-client-go/v2 v2.26.0 h1:bZr0hu+hx8L91+yU5EGw8wK3FlCVEIashpx+cylWsf0=
+github.com/DataDog/datadog-api-client-go/v2 v2.26.0/go.mod h1:QKOu6vscsh87fMY1lHfLEmNSunyXImj8BUaUWJXOehc=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-go v4.8.3+incompatible h1:fNGaYSuObuQb5nzeTQqowRAd9bpDIRRV4/gUtIBjh8Q=
 github.com/DataDog/datadog-go v4.8.3+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
+github.com/DataDog/zstd v1.5.2 h1:vUG4lAyuPCXO0TLbXvPv7EB7cNK1QV/luu55UHLrrn8=
+github.com/DataDog/zstd v1.5.2/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/PuerkitoBio/goquery v1.5.1/go.mod h1:GsLWisAFVj4WgDibEWF4pvYnkVQBpKBKeU+7zCJoLcc=
@@ -17,8 +21,6 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
-github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -64,6 +66,8 @@ github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg78
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
+github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
+github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
@@ -236,8 +240,6 @@ github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
-github.com/zorkian/go-datadog-api v2.30.0+incompatible h1:R4ryGocppDqZZbnNc5EDR8xGWF/z/MxzWnqTUijDQes=
-github.com/zorkian/go-datadog-api v2.30.0+incompatible/go.mod h1:PkXwHX9CUQa/FpB9ZwAD45N1uhCW4MT/Wj7m36PbKss=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190325154230-a5d413f7728c/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=


### PR DESCRIPTION
Switching datadog integration library to the https://github.com/DataDog/datadog-api-client-go official go library as the original is no longer being maintained.

Also extended ENV to define APP_KEY and API_KEY for datadog.